### PR TITLE
#8 Factor out common schema definitions

### DIFF
--- a/schema/FieldMeasurement.xsd
+++ b/schema/FieldMeasurement.xsd
@@ -6,6 +6,9 @@
 	<!--  -->
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
 	<import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+	<include schemaLocation="commonTypes.xsd"/>
+	<include schemaLocation="ObservationSystem.xsd"/>
+	<include schemaLocation="Project.xsd"/>
 	<!--  -->
 	<complexType name="SetupPropertyType">
 		<sequence minOccurs="0">
@@ -48,26 +51,6 @@
 					<element name="observedBy" type="gmd:CI_ResponsibleParty_PropertyType" minOccurs="0"/>
 					<element name="usesInstrument" type="geo:InstrumentPropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<element name="usesSensor" type="geo:SensorPropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<group ref="geo:RemarksGroup"/>
-				</sequence>
-			</extension>
-		</complexContent>
-	</complexType>
-	<!--  -->
-	<complexType name="InstrumentPropertyType">
-		<sequence minOccurs="0">
-			<element ref="geo:Instrument"/>
-		</sequence>
-		<attributeGroup ref="gml:AssociationAttributeGroup"/>
-	</complexType>
-	<!--  -->
-	<element name="Instrument" type="geo:InstrumentType" substitutionGroup="gml:AbstractGML"/>
-	<!--  -->
-	<complexType name="InstrumentType">
-		<complexContent>
-			<extension base="gml:AbstractGMLType">
-				<sequence>
-					<element name="type" type="gml:CodeType" minOccurs="0"/>
 					<group ref="geo:RemarksGroup"/>
 				</sequence>
 			</extension>

--- a/schema/GeodesyML.xsd
+++ b/schema/GeodesyML.xsd
@@ -8,6 +8,7 @@
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
 	<import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
 	<!--  -->
+	<include schemaLocation="commonTypes.xsd"/>
 	<include schemaLocation="Quality.xsd"/>
 	<include schemaLocation="ObservationSystem.xsd"/>
 	<include schemaLocation="Lineage.xsd"/>
@@ -65,79 +66,4 @@
 		</complexContent>
 	</complexType>
 	<!--  -->
-	<attributeGroup name="RequiredSRSReferenceGroup">
-		<annotation>
-			<documentation>The attribute group SRSReferenceGroup is a required reference to the CRS used by this geometry, with optional additional information to simplify the processing of the coordinates when a more complete definition of the CRS is not needed.
-In general the attribute srsName points to a CRS instance of gml:AbstractCoordinateReferenceSystem. For well-known references it is not required that the CRS description exists at the location the URI points to. 
-If no srsName attribute is given, the CRS shall be specified as part of the larger context this geometry element is part of.</documentation>
-		</annotation>
-		<attribute name="srsName" type="anyURI" use="required"/>
-		<attribute name="srsDimension" type="positiveInteger"/>
-		<attributeGroup ref="gml:SRSInformationGroup"/>
-	</attributeGroup>
-	<!--  -->
-	<group name="RemarksGroup">
-		<annotation>
-			<documentation>A convenience group. This allows an application schema developer to include remarks and associated documents in a standard fashion.</documentation>
-		</annotation>
-		<sequence>
-			<element name="remarks" type="string" minOccurs="0"/>
-			<element name="associatedDocument" type="geo:DocumentPropertyType" minOccurs="0" maxOccurs="unbounded"/>
-			<element name="extension" type="anyType" minOccurs="0"/>
-		</sequence>
-	</group>
-	<!--  -->
-	<element name="DynamicFeature" type="geo:DynamicFeatureType" abstract="true" substitutionGroup="gml:AbstractFeature">
-		<annotation>
-			<documentation>Restriction of the gml:DynamicFeatureType. Removes gml:history and relies upon the extending type to implement a history element that restricts child types to those allowed by the class model.</documentation>
-		</annotation>
-	</element>
-	<!--  -->
-	<complexType name="DynamicFeatureType">
-		<complexContent>
-			<restriction base="gml:DynamicFeatureType">
-				<sequence>
-					<sequence>
-						<group ref="gml:StandardObjectProperties"/>
-					</sequence>
-					<sequence>
-						<element ref="gml:boundedBy" minOccurs="0"/>
-						<element ref="gml:location" minOccurs="0"/>
-					</sequence>
-					<sequence>
-						<element ref="gml:validTime" minOccurs="0"/>
-						<element ref="gml:dataSource" minOccurs="0"/>
-						<element ref="gml:dataSourceReference" minOccurs="0"/>
-					</sequence>
-				</sequence>
-			</restriction>
-		</complexContent>
-	</complexType>
-	<!--  -->
-	<element name="AbstractTimeSlice" type="geo:AbstractTimeSliceType" abstract="true" substitutionGroup="gml:AbstractFeature">
-		<annotation>
-			<documentation>Mimics the gml:AbstractTimeSlice element but extends gml:AbstractFeatureType instead of gml:AbstractGMLType. The purpose of making this distinction is to ensure better access to a wider variety of WFS solutions that use the gml:AbstractFeature/gml:Location element for visualisation. 
-</documentation>
-		</annotation>
-	</element>
-	<!--  -->
-	<complexType name="AbstractTimeSliceType" abstract="true">
-		<complexContent>
-			<extension base="gml:AbstractFeatureType">
-				<sequence>
-					<group ref="geo:TimeSliceProperties"/>
-				</sequence>
-			</extension>
-		</complexContent>
-	</complexType>
-	<!--  -->
-	<group name="TimeSliceProperties">
-		<annotation>
-			<documentation/>
-		</annotation>
-		<sequence>
-			<element ref="gml:validTime"/>
-			<element ref="gml:dataSource" minOccurs="0"/>
-		</sequence>
-	</group>
 </schema>

--- a/schema/Lineage.xsd
+++ b/schema/Lineage.xsd
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.2" xmlns:om="http://www.opengis.net/om/2.0" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.2" elementFormDefault="qualified" version="0.2.0" xml:lang="en">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd"
+	xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.2" xmlns:om="http://www.opengis.net/om/2.0" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.2" elementFormDefault="qualified"
+	version="0.2.0" xml:lang="en">
 	<annotation>
 		<documentation>eGeodesy schema implementation based on GML - draft. Copyright (c) 2013-2015 Commonwealth of Australia, on behalf of the Intergovernmental Committee on Surveying and Mapping. All rights reserved.</documentation>
 	</annotation>
@@ -7,6 +9,11 @@
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
 	<import namespace="http://www.opengis.net/om/2.0" schemaLocation="http://schemas.opengis.net/om/2.0/observation.xsd"/>
 	<import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+	<!--  -->
+	<include schemaLocation="commonTypes.xsd"/>
+	<include schemaLocation="Quality.xsd"/>
+	<include schemaLocation="ObservationSystem.xsd"/>
+	<include schemaLocation="Measurement.xsd"/>
 	<!--  -->
 	<complexType name="AbstractSourcePropertyType">
 		<sequence minOccurs="0">

--- a/schema/Measurement.xsd
+++ b/schema/Measurement.xsd
@@ -5,6 +5,11 @@
 	</annotation>
 	<!--  -->
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<include schemaLocation="commonTypes.xsd"/>
+	<include schemaLocation="Quality.xsd"/>
+	<include schemaLocation="Project.xsd"/>
+	<include schemaLocation="Lineage.xsd"/>
+	<include schemaLocation="FieldMeasurement.xsd"/>
 	<!--  -->
 	<complexType name="AbstractMeasurementPropertyType">
 		<sequence minOccurs="0">

--- a/schema/ObservationSystem.xsd
+++ b/schema/ObservationSystem.xsd
@@ -8,6 +8,10 @@
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
 	<import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
 	<import namespace="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"/>
+	<include schemaLocation="commonTypes.xsd"/>
+	<include schemaLocation="Document.xsd"/>
+	<include schemaLocation="Quality.xsd"/>
+	<include schemaLocation="Lineage.xsd"/>
 	<!--  -->
 	<complexType name="AbstractMonumentType" abstract="true">
 		<annotation>

--- a/schema/Project.xsd
+++ b/schema/Project.xsd
@@ -6,6 +6,7 @@
 	<!--  -->
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
 	<import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+	<include schemaLocation="commonTypes.xsd"/>
 	<!--  -->
 	<complexType name="ProjectPropertyType">
 		<sequence minOccurs="0">

--- a/schema/ReferenceFrame.xsd
+++ b/schema/ReferenceFrame.xsd
@@ -6,6 +6,7 @@
 	</annotation>
 	<!--  -->
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<include schemaLocation="Lineage.xsd"/>
 	<!--  -->
 	<complexType name="TerrestrialReferenceFramePropertyType">
 		<sequence minOccurs="0">

--- a/schema/commonTypes.xsd
+++ b/schema/commonTypes.xsd
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.2" xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.2" elementFormDefault="qualified" version="0.2.0" xml:lang="en">
+    <annotation>
+        <documentation>eGeodesy schema implementation based on GML - draft. Copyright (c) 2015-2016 Commonwealth of Australia, on behalf of the Intergovernmental Committee on Surveying and Mapping. All rights reserved.</documentation>
+    </annotation>
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <include schemaLocation="Document.xsd"/>
+    <!--  -->
+    <group name="RemarksGroup">
+        <annotation>
+            <documentation>A convenience group. This allows an application schema developer to include remarks and associated documents in a standard fashion.</documentation>
+        </annotation>
+        <sequence>
+            <element name="remarks" type="string" minOccurs="0"/>
+            <element name="associatedDocument" type="geo:DocumentPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+            <element name="extension" type="anyType" minOccurs="0"/>
+        </sequence>
+    </group>
+    <!-- Change tracking group -->
+    <group name="ChangeTracking">
+        <annotation>
+            <documentation>A convenience group to log changes made to each meta-data block.</documentation>
+        </annotation>
+        <sequence>
+            <sequence minOccurs="0">
+                <element name="dateInserted" type="gml:TimePositionType"/>
+                <sequence minOccurs="0">
+                    <element name="dateDeleted" type="gml:TimePositionType"/>
+                    <element name="deletedReason" type="string"/>
+                </sequence>
+            </sequence>
+        </sequence>
+    </group>
+    <!--  -->
+    <attributeGroup name="RequiredSRSReferenceGroup">
+        <annotation>
+            <documentation>The attribute group SRSReferenceGroup is a required reference to the CRS used by this geometry, with optional additional information to simplify the processing of the coordinates when a more complete definition of the CRS is not needed.
+                In general the attribute srsName points to a CRS instance of gml:AbstractCoordinateReferenceSystem. For well-known references it is not required that the CRS description exists at the location the URI points to. 
+                If no srsName attribute is given, the CRS shall be specified as part of the larger context this geometry element is part of.</documentation>
+        </annotation>
+        <attribute name="srsName" type="anyURI" use="required"/>
+        <attribute name="srsDimension" type="positiveInteger"/>
+        <attributeGroup ref="gml:SRSInformationGroup"/>
+    </attributeGroup>
+    <!--  -->
+    <group name="TimeSliceProperties">
+        <annotation>
+            <documentation/>
+        </annotation>
+        <sequence>
+            <element ref="gml:validTime"/>
+            <element ref="gml:dataSource" minOccurs="0"/>
+        </sequence>
+    </group>
+    <!--  -->
+    <complexType name="DynamicFeatureType">
+        <complexContent>
+            <restriction base="gml:DynamicFeatureType">
+                <sequence>
+                    <sequence>
+                        <group ref="gml:StandardObjectProperties"/>
+                    </sequence>
+                    <sequence>
+                        <element ref="gml:boundedBy" minOccurs="0"/>
+                        <element ref="gml:location" minOccurs="0"/>
+                    </sequence>
+                    <sequence>
+                        <element ref="gml:validTime" minOccurs="0"/>
+                        <element ref="gml:dataSource" minOccurs="0"/>
+                        <element ref="gml:dataSourceReference" minOccurs="0"/>
+                    </sequence>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="DynamicFeature" type="geo:DynamicFeatureType" abstract="true" substitutionGroup="gml:AbstractFeature">
+        <annotation>
+            <documentation>Restriction of the gml:DynamicFeatureType. Removes gml:history and relies upon the extending type to implement a history element that restricts child types to those allowed by the class model.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="InstrumentPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Instrument"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="AbstractTimeSlice" type="geo:AbstractTimeSliceType" abstract="true" substitutionGroup="gml:AbstractFeature">
+        <annotation>
+            <documentation>Mimics the gml:AbstractTimeSlice element but extends gml:AbstractFeatureType instead of gml:AbstractGMLType. The purpose of making this distinction is to ensure better access to a wider variety of WFS solutions that use the gml:AbstractFeature/gml:Location element for visualisation. 
+            </documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="AbstractTimeSliceType" abstract="true">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <group ref="geo:TimeSliceProperties"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="Instrument" type="geo:InstrumentType" substitutionGroup="gml:AbstractGML"/>
+    <!--  -->
+    <complexType name="InstrumentType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element name="type" type="gml:CodeType" minOccurs="0"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+</schema>

--- a/schema/equipment.xsd
+++ b/schema/equipment.xsd
@@ -3,6 +3,8 @@
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
 	<include schemaLocation="geodeticEquipment.xsd"/>
 	<include schemaLocation="FieldMeasurement.xsd"/>
+	<include schemaLocation="Measurement.xsd"/>
+	<include schemaLocation="commonTypes.xsd"/>
 	<annotation>
 		<documentation>
      Filename     : baseEquipmentLib.xsd

--- a/schema/geodeticEquipment.xsd
+++ b/schema/geodeticEquipment.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.2" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.2" elementFormDefault="qualified" version="0.2.0" xml:lang="en">
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<include schemaLocation="FieldMeasurement.xsd"/>
 	<annotation>
 		<documentation>
 	Author       : Michael Scharber

--- a/schema/geodeticMonument.xsd
+++ b/schema/geodeticMonument.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.2" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.2" elementFormDefault="qualified" version="0.2.0" xml:lang="en">
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<include schemaLocation="ObservationSystem.xsd"/>
 	<annotation>
 		<documentation>
 	Author       : Michael Scharber

--- a/schema/localInterferences.xsd
+++ b/schema/localInterferences.xsd
@@ -6,6 +6,7 @@ located in baseLocalInterferences.xsd.  can not use these without getting errors
 <include schemaLocation="../localInterferences/multiPath.xsd"/>
 -->
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<include schemaLocation="commonTypes.xsd"/>
 	<annotation>
 		<documentation>
      Filename     : baseLocalInterferencesLib.xsd

--- a/schema/siteLog.xsd
+++ b/schema/siteLog.xsd
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- edited with XMLSpy v2009 sp1 (http://www.altova.com) by DEPT OF SUSTAINABILITY & ENVIRONMENT (DEPT OF SUSTAINABILITY & ENVIRONMENT) -->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.2" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.2" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.2.0" xml:lang="en">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd"
+	xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.2" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.2" elementFormDefault="qualified" attributeFormDefault="unqualified"
+	version="0.2.0" xml:lang="en">
 	<annotation>
 		<documentation>
      Filename     : siteLog.xsd
@@ -31,6 +33,7 @@
 	<include schemaLocation="localInterferences.xsd"/>
 	<include schemaLocation="contact.xsd"/>
 	<include schemaLocation="dataStreams.xsd"/>
+	<include schemaLocation="ObservationSystem.xsd"/>
 	<complexType name="SiteLogType">
 		<annotation>
 			<documentation>
@@ -70,19 +73,4 @@
 		</complexContent>
 	</complexType>
 	<element name="siteLog" type="geo:SiteLogType" substitutionGroup="geo:AbstractSiteLog"/>
-	<!-- Change tracking group -->
-	<group name="ChangeTracking">
-		<annotation>
-			<documentation>A convenience group to log changes made to each meta-data block.</documentation>
-		</annotation>
-		<sequence>
-			<sequence minOccurs="0">
-				<element name="dateInserted" type="gml:TimePositionType"/>
-				<sequence minOccurs="0">
-					<element name="dateDeleted" type="gml:TimePositionType"/>
-					<element name="deletedReason" type="string"/>
-				</sequence>
-			</sequence>
-		</sequence>
-	</group>
 </schema>


### PR DESCRIPTION
* #8 
* Moved definitions from GeodesyML.xsd and other xsd's to commonTypes.xsd and updated references in other files to this
* Also added includes to all xsds to other local xsds so they are valid in and of themselves (before they were valid only if they came under the top-level GeodesyML.xsd)

Remember to delete branch after its merged.