### PR TITLE
 #27 Other Instrumentation Dates fix

### DIFF
--- a/schema/equipment.xsd
+++ b/schema/equipment.xsd
@@ -255,7 +255,8 @@
 			<extension base="geo:InstrumentType">
 				<sequence>
 					<element name="instrumentation" type="string"/>
-					<element ref="gml:validTime"/>
+					<element name="effectiveStartDate" type="gml:TimePositionType" minOccurs="0"/>
+					<element name="effectiveEndDate" type="gml:TimePositionType" minOccurs="0"/>
 				</sequence>
 			</extension>
 		</complexContent>


### PR DESCRIPTION
* Based on
http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/otherInstrumentation.xsd
that is referred to in the issue.
* Removed existing `<gml:validTime` element as it looks like an attempt
at fixing dates and not in SOPAC.
* Added `<effectiveStartDate` and `<effectiveEndDate` as specified in
issue.

Resolve #27 