### PR TITLE
Change declared xslt version

### DIFF
--- a/tools/schematron/schematron/iso_svrl_for_xslt2_with_diagnostics.xsl
+++ b/tools/schematron/schematron/iso_svrl_for_xslt2_with_diagnostics.xsl
@@ -3,7 +3,7 @@
   xmlns:axsl="http://www.w3.org/1999/XSL/TransformAlias"
   xmlns:iso="http://purl.oclc.org/dsdl/schematron"
   xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-  version="1.0">
+  version="2.0">
   <xsl:import href="iso_svrl_for_xslt2.xsl"/>
 
   <xsl:output method="xml" indent="yes" encoding="utf-8"/>


### PR DESCRIPTION
Is this OK? It gets rid of this warning:
```
Warning: at xsl:stylesheet on line 6 column 17 of iso_svrl_for_xslt2_with_diagnostics.xsl:
  Running an XSLT 10 stylesheet with an XSLT 20 processor
```