### PR TITLE
 #68 Allow codelists to have FQDN URI

### DIFF
--- a/examples/MOBS-more-info-multiple-datacenters.xml
+++ b/examples/MOBS-more-info-multiple-datacenters.xml
@@ -37,7 +37,7 @@
 	</geo:Monument>
 	<geo:gnssReceiver gml:id="GNSS_REC_1">
 		<geo:manufacturerSerialNumber>ZR220012001</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>ZR220012001</geo:serialNumber>
 		<geo:firmwareVersion>CK00</geo:firmwareVersion>
@@ -49,7 +49,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_2">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.00/3.019</geo:firmwareVersion>
@@ -61,7 +61,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_3">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.71/3.822</geo:firmwareVersion>
@@ -73,7 +73,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_4">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>7.50</geo:firmwareVersion>
@@ -85,7 +85,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_5">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.01/3.019</geo:firmwareVersion>
@@ -97,7 +97,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_6">
 		<geo:manufacturerSerialNumber>462891</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200PRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200PRO</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>462891</geo:serialNumber>
 		<geo:firmwareVersion>3.10</geo:firmwareVersion>
@@ -109,7 +109,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_7">
 		<geo:manufacturerSerialNumber>ZR520021114</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>ZR520021114</geo:serialNumber>
 		<geo:firmwareVersion>ZC00</geo:firmwareVersion>
@@ -121,7 +121,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_8">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>6.02</geo:firmwareVersion>
@@ -133,7 +133,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_9">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>7.50/3.019</geo:firmwareVersion>
@@ -145,7 +145,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssAntenna gml:id="GNSS_ANT_2">
 		<geo:manufacturerSerialNumber>CR20020709</geo:manufacturerSerialNumber>
-		<geo:antennaType codeSpace="urn:igs-org:gnss-antenna-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="ASH701945C_M">ASH701945C_M</geo:antennaType>
+		<geo:antennaType codeSpace="urn:igs-org:gnss-antenna-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="ASH701945C_M">ASH701945C_M</geo:antennaType>
 		<geo:serialNumber>CR20020709</geo:serialNumber>
 		<geo:antennaReferencePoint>BPA</geo:antennaReferencePoint>
 		<geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
@@ -344,7 +344,7 @@
 			</geo:frequencyStandard>
 		</geo:frequencyStandard>
 		<geo:agency gml:id="CONTAGENCY_1">
-			<geo:agencyRole codeList="../../codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ContactAgency">Contact Agency</geo:agencyRole>
+			<geo:agencyRole codeList="http://xml.gov.au/icsm/geodesyml/codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ContactAgency">Contact Agency</geo:agencyRole>
 			<geo:agencyName>Geoscience Australia</geo:agencyName>
 			<geo:preferredAbbreviation>GA</geo:preferredAbbreviation>
 			<geo:mailingAddress>
@@ -360,7 +360,7 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>ryan.ruddick@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>
 			<geo:contact>
@@ -370,12 +370,12 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>bob.twilley@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Secondary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Secondary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>	
 		</geo:agency>
 		<geo:agency gml:id="RESPONSEAGENCY_1">
-			<geo:agencyRole codeList="../../codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ResponsibleAgency">Responsible Agency</geo:agencyRole>
+			<geo:agencyRole codeList="http://xml.gov.au/icsm/geodesyml/codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ResponsibleAgency">Responsible Agency</geo:agencyRole>
 			<geo:agencyName>Geoscience Australia</geo:agencyName>
 			<geo:preferredAbbreviation>GA</geo:preferredAbbreviation>
 			<geo:mailingAddress>
@@ -391,7 +391,7 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>bob.twilley@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>
 		</geo:agency>

--- a/examples/MOBS-multiple-satellite-systems.xml
+++ b/examples/MOBS-multiple-satellite-systems.xml
@@ -38,7 +38,7 @@
 	</geo:Monument>
 	<geo:gnssReceiver gml:id="GNSS_REC_1">
 		<geo:manufacturerSerialNumber>ZR220012001</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>ZR220012001</geo:serialNumber>
 		<geo:firmwareVersion>CK00</geo:firmwareVersion>
@@ -50,7 +50,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_2">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.00/3.019</geo:firmwareVersion>
@@ -62,7 +62,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_3">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.71/3.822</geo:firmwareVersion>
@@ -74,7 +74,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_4">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>7.50</geo:firmwareVersion>
@@ -86,7 +86,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_5">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.01/3.019</geo:firmwareVersion>
@@ -98,7 +98,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_6">
 		<geo:manufacturerSerialNumber>462891</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200PRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200PRO</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>462891</geo:serialNumber>
 		<geo:firmwareVersion>3.10</geo:firmwareVersion>
@@ -110,7 +110,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_7">
 		<geo:manufacturerSerialNumber>ZR520021114</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>ZR520021114</geo:serialNumber>
 		<geo:firmwareVersion>ZC00</geo:firmwareVersion>
@@ -122,7 +122,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_8">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>6.02</geo:firmwareVersion>
@@ -134,7 +134,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_9">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>7.50/3.019</geo:firmwareVersion>
@@ -146,7 +146,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssAntenna gml:id="GNSS_ANT_2">
 		<geo:manufacturerSerialNumber>CR20020709</geo:manufacturerSerialNumber>
-		<geo:antennaType codeSpace="urn:igs-org:gnss-antenna-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="ASH701945C_M">ASH701945C_M</geo:antennaType>
+		<geo:antennaType codeSpace="urn:igs-org:gnss-antenna-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="ASH701945C_M">ASH701945C_M</geo:antennaType>
 		<geo:serialNumber>CR20020709</geo:serialNumber>
 		<geo:antennaReferencePoint>BPA</geo:antennaReferencePoint>
 		<geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
@@ -345,7 +345,7 @@
 			</geo:frequencyStandard>
 		</geo:frequencyStandard>
 		<geo:agency gml:id="CONTAGENCY_1">
-			<geo:agencyRole codeList="../../codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ContactAgency">Contact Agency</geo:agencyRole>
+			<geo:agencyRole codeList="http://xml.gov.au/icsm/geodesyml/codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ContactAgency">Contact Agency</geo:agencyRole>
 			<geo:agencyName>Geoscience Australia</geo:agencyName>
 			<geo:preferredAbbreviation>GA</geo:preferredAbbreviation>
 			<geo:mailingAddress>
@@ -361,7 +361,7 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>ryan.ruddick@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>
 			<geo:contact>
@@ -371,12 +371,12 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>bob.twilley@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Secondary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Secondary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>	
 		</geo:agency>
 		<geo:agency gml:id="RESPONSEAGENCY_1">
-			<geo:agencyRole codeList="../../codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ResponsibleAgency">Responsible Agency</geo:agencyRole>
+			<geo:agencyRole codeList="http://xml.gov.au/icsm/geodesyml/codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ResponsibleAgency">Responsible Agency</geo:agencyRole>
 			<geo:agencyName>Geoscience Australia</geo:agencyName>
 			<geo:preferredAbbreviation>GA</geo:preferredAbbreviation>
 			<geo:mailingAddress>
@@ -392,7 +392,7 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>bob.twilley@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>
 		</geo:agency>

--- a/examples/MOBS.xml
+++ b/examples/MOBS.xml
@@ -38,7 +38,7 @@
 	</geo:Monument>
 	<geo:gnssReceiver gml:id="GNSS_REC_1">
 		<geo:manufacturerSerialNumber>ZR220012001</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>ZR220012001</geo:serialNumber>
 		<geo:firmwareVersion>CK00</geo:firmwareVersion>
@@ -50,7 +50,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_2">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.00/3.019</geo:firmwareVersion>
@@ -62,7 +62,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_3">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.71/3.822</geo:firmwareVersion>
@@ -74,7 +74,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_4">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>7.50</geo:firmwareVersion>
@@ -86,7 +86,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_5">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>8.01/3.019</geo:firmwareVersion>
@@ -98,7 +98,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_6">
 		<geo:manufacturerSerialNumber>462891</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200PRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200PRO</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>462891</geo:serialNumber>
 		<geo:firmwareVersion>3.10</geo:firmwareVersion>
@@ -110,7 +110,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_7">
 		<geo:manufacturerSerialNumber>ZR520021114</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:receiverType>
 		<geo:satelliteSystem>GPS</geo:satelliteSystem>
 		<geo:serialNumber>ZR520021114</geo:serialNumber>
 		<geo:firmwareVersion>ZC00</geo:firmwareVersion>
@@ -122,7 +122,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_8">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>6.02</geo:firmwareVersion>
@@ -134,7 +134,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssReceiver gml:id="GNSS_REC_9">
 		<geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
-		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
+		<geo:receiverType codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:receiverType>
 		<geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
 		<geo:serialNumber>356538</geo:serialNumber>
 		<geo:firmwareVersion>7.50/3.019</geo:firmwareVersion>
@@ -146,7 +146,7 @@
 	</geo:gnssReceiver>
 	<geo:gnssAntenna gml:id="GNSS_ANT_2">
 		<geo:manufacturerSerialNumber>CR20020709</geo:manufacturerSerialNumber>
-		<geo:antennaType codeSpace="urn:igs-org:gnss-antenna-model-code" codeList="../../codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="ASH701945C_M">ASH701945C_M</geo:antennaType>
+		<geo:antennaType codeSpace="urn:igs-org:gnss-antenna-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="ASH701945C_M">ASH701945C_M</geo:antennaType>
 		<geo:serialNumber>CR20020709</geo:serialNumber>
 		<geo:antennaReferencePoint>BPA</geo:antennaReferencePoint>
 		<geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
@@ -345,7 +345,7 @@
 			</geo:frequencyStandard>
 		</geo:frequencyStandard>
 		<geo:agency gml:id="CONTAGENCY_1">
-			<geo:agencyRole codeList="../../codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ContactAgency">Contact Agency</geo:agencyRole>
+			<geo:agencyRole codeList="http://xml.gov.au/icsm/geodesyml/codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ContactAgency">Contact Agency</geo:agencyRole>
 			<geo:agencyName>Geoscience Australia</geo:agencyName>
 			<geo:preferredAbbreviation>GA</geo:preferredAbbreviation>
 			<geo:mailingAddress>
@@ -361,7 +361,7 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>ryan.ruddick@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>
 			<geo:contact>
@@ -371,12 +371,12 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>bob.twilley@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Secondary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Secondary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>	
 		</geo:agency>
 		<geo:agency gml:id="RESPONSEAGENCY_1">
-			<geo:agencyRole codeList="../../codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ResponsibleAgency">Responsible Agency</geo:agencyRole>
+			<geo:agencyRole codeList="http://xml.gov.au/icsm/geodesyml/codelists/agency-roles-codelists.xml#Role-Agency" codeListValue="ResponsibleAgency">Responsible Agency</geo:agencyRole>
 			<geo:agencyName>Geoscience Australia</geo:agencyName>
 			<geo:preferredAbbreviation>GA</geo:preferredAbbreviation>
 			<geo:mailingAddress>
@@ -392,7 +392,7 @@
 				<geo:fax>+61 2 6249 9929</geo:fax>
 				<geo:e-mail>bob.twilley@ga.gov.au</geo:e-mail>
 				<geo:role>
-					<gmd:CI_RoleCode codeList="../../codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+					<gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Primary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
 				</geo:role>
 			</geo:contact>
 		</geo:agency>

--- a/tools/schematron/codeListValidation.sch
+++ b/tools/schematron/codeListValidation.sch
@@ -10,7 +10,16 @@
     <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
     <sch:pattern id="checkCodeList">
         <sch:rule context="//*[@codeList]">
-            <sch:let name="codeListDoc" value="document(substring-before(@codeList,'#'))//gmx:CodeListDictionary[@gml:id = substring-after(current()/@codeList,'#')]"/>
+            <!--
+                 Replace 'http://xml.gov.au/icsm/geodesyml' with '../..' so we can allow codelists to be:
+
+                 <gmd:CI_RoleCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Secondary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+
+                 Instead of the 'developer' view of:
+
+                 <gmd:CI_RoleCode codeList="../../geodesyml/codelists/contacts-roles-codelists.xml#Role-Contact" codeListValue="Secondary">Technical Officer, Geodesy &amp; Seismic Monitoring Group</gmd:CI_RoleCode>
+            -->
+            <sch:let name="codeListDoc" value="document(replace(string(substring-before(@codeList,'#')),string('http://xml.gov.au/icsm/geodesyml'),string('../..')))//gmx:CodeListDictionary[@gml:id = substring-after(current()/@codeList,'#')]"/>
             <sch:assert test="$codeListDoc">Unable to find the specified codeList document or CodeListDictionary node.</sch:assert>
             <sch:assert test="@codeListValue = $codeListDoc/gmx:codeEntry/gmx:CodeDefinition/gml:identifier" diagnostics="desc.diag">codeListValue is not in the specified codeList.</sch:assert>
         </sch:rule>


### PR DESCRIPTION
* Replace 'http://xml.gov.au/icsm/geodesyml' with '../..' so codeLists
can look production-ready.

Resolves #68