### PR TITLE
 #79 Fix FaultZoneNearbyType enumeration

### DIFF
--- a/schemas/monumentInfo.xsd
+++ b/schemas/monumentInfo.xsd
@@ -238,7 +238,14 @@
             <element name="bedrockType" type="string"/>
             <element name="bedrockCondition" type="string"/>
             <element name="fractureSpacing" type="string"/>
-            <element name="faultZonesNearby" type="geo:faultZonesNearbyType"/>
+            <element name="faultZonesNearby" type="gml:CodeWithAuthorityType">
+                <annotation>
+                    <documentation>Temporarily changing this from `geo:faultZonesNearbyType` since it a) has a blank enumeration forcing
+                        JAXB to make the values to 'VALUE_1', 'VALUE_2' etc... instaed of 'Yes', 'No' etc. And b) because it includes an
+                        enumeration of 'Name_of_Zone' which does not make sense as an enumeration. It is now, which resolves to a
+                        xsd:string. </documentation>
+                </annotation>
+            </element>
             <element name="distance-Activity" type="string"/>
             <element name="notes" type="string"/>
         </sequence>


### PR DESCRIPTION
* Change from an enumeration to xsd:string (effectively).
* This because the enumeration contains a blank option which forces
JAXB to make the enumerations be 'VALUE_1','VALUE_2' etc.  And
because one of the enumerations is 'NAME_OF_ZONE' which implies more
information must be given but there is no provision for that.
* Nick Brown has been made aware of this problem and asked what to do.