### PR TITLE
Make date in frequencyStandards work-able.

### DIFF
--- a/schemas/equipment.xsd
+++ b/schemas/equipment.xsd
@@ -231,7 +231,7 @@
 						</annotation>
 					</element>
 					<element name="inputFrequency" type="string"/>
-					<element name="effectiveDate" type="gml:TimePeriodType">
+					<element name="effectiveDates" type="gml:TimePeriodType">
 						<annotation>
 							<documentation>Changed from ref to gml:validTime to gml:TimePeriodType as the former is ineffective.  It is a period so can express Begin and End dates.</documentation>
 						</annotation>


### PR DESCRIPTION
Changed from ref to gml:validTime to gml:TimePeriodType as the former is
ineffective (there is no place to enter any data of value).
It is a period so can express Begin and End dates.