### PR TITLE
GEOD-62 Remove local reference to RemarksGroup

### DIFF
--- a/schemas/lineage.xsd
+++ b/schemas/lineage.xsd
@@ -553,9 +553,6 @@ Copyright: Commonwealth Government (Geoscience Australia) 2016
         </annotation>
         <complexContent>
             <extension base="geo:AbstractDefinitionSourceType">
-                <sequence>
-                    <group ref="geo:RemarksGroup"/>
-                </sequence>
                 <attributeGroup ref="gml:SRSReferenceGroup"/>
             </extension>
             <!--<attributeGroup ref="geo:SpatialReferenceGroup"/>-->


### PR DESCRIPTION
Attribute remarks group is already present due to AbstractSource super
type.

See https://gaautobots.atlassian.net/browse/GEOD-62.