### PR TITLE
Make SiteLocation extend AbstractGMLType

### DIFF
--- a/examples/0.5/20na_20161027.xml
+++ b/examples/0.5/20na_20161027.xml
@@ -28,7 +28,7 @@ is affixed to concrete on roof top of
 Alice Plaza building</geo:notes>
         </geo:siteIdentification>
         <geo:siteLocation>
-            <geo:SiteLocation>
+            <geo:SiteLocation gml:id="site-location">
                 <geo:city>Alice Springs</geo:city>
                 <geo:state>Northern Territory</geo:state>
                 <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>

--- a/examples/0.5/21na_20161027.xml
+++ b/examples/0.5/21na_20161027.xml
@@ -28,7 +28,7 @@ is affixed to concrete on roof top of building
 DOMES number changed from APREF to IERS</geo:notes>
         </geo:siteIdentification>
         <geo:siteLocation>
-            <geo:SiteLocation>
+            <geo:SiteLocation gml:id="site-location">
                 <geo:city>Alice Springs</geo:city>
                 <geo:state>Northern Territory</geo:state>
                 <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>

--- a/examples/0.5/MOBS.xml
+++ b/examples/0.5/MOBS.xml
@@ -239,7 +239,7 @@
             <geo:notes>antenna mounting plate fixed to 1.5m stainless steel pole. Pole is fixed to 0.6m diameter bluestone pillar The GPS antenna is located on top of a stainless steel pillar, which has been secured into the top of a bluestone pillar set in bedrock</geo:notes>
         </geo:siteIdentification>
         <geo:siteLocation>
-            <geo:SiteLocation>
+            <geo:SiteLocation gml:id="site-location">
                 <geo:city>Melbourne</geo:city>
                 <geo:state>Victoria</geo:state>
                 <geo:countryCodeISO codeSpace="urn:igs-org:gnss-country-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS">AUS</geo:countryCodeISO>

--- a/examples/0.5/bboo_20170223.xml
+++ b/examples/0.5/bboo_20170223.xml
@@ -26,7 +26,7 @@
             <geo:notes></geo:notes>
         </geo:siteIdentification>
         <geo:siteLocation>
-            <geo:SiteLocation>
+            <geo:SiteLocation gml:id="site-location">
                 <geo:city>Buckleboo</geo:city>
                 <geo:state>South Australia</geo:state>
                 <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>

--- a/examples/0.5/bcus_20150709.xml
+++ b/examples/0.5/bcus_20150709.xml
@@ -26,7 +26,7 @@
             <geo:notes></geo:notes>
         </geo:siteIdentification>
         <geo:siteLocation>
-            <geo:SiteLocation>
+            <geo:SiteLocation gml:id="site-location">
                 <geo:city>Bacchus Marsh</geo:city>
                 <geo:state>Victoria</geo:state>
                 <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>

--- a/examples/0.5/bdle_20150212.xml
+++ b/examples/0.5/bdle_20150212.xml
@@ -26,7 +26,7 @@
             <geo:notes></geo:notes>
         </geo:siteIdentification>
         <geo:siteLocation>
-            <geo:SiteLocation>
+            <geo:SiteLocation gml:id="site-location">
                 <geo:city>Bairnsdale</geo:city>
                 <geo:state>Victoria</geo:state>
                 <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>

--- a/examples/0.5/yar3_20140709.xml
+++ b/examples/0.5/yar3_20140709.xml
@@ -32,7 +32,7 @@ Program
 Memorandum 4482&quot; p631.</geo:notes>
         </geo:siteIdentification>
         <geo:siteLocation>
-            <geo:SiteLocation>
+            <geo:SiteLocation gml:id="site-location">
                 <geo:city>Yarragadee</geo:city>
                 <geo:state>Western Australia</geo:state>
                 <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>

--- a/schemas/geodesyml/0.5/monumentInfo.xsd
+++ b/schemas/geodesyml/0.5/monumentInfo.xsd
@@ -237,24 +237,28 @@ Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Govern
     <element name="SiteLocation" type="geo:SiteLocationType"/>
     
     <complexType name="SiteLocationType">
-        <sequence>
-            <element name="city" type="string"/>
-            <element name="state" type="string"/>
-            <element name="countryCodeISO" type="geo:countryCodeType" />
-            <!-- TODO: use gco -->
-            <element name="tectonicPlate" type="gml:CodeType"/>
-            
-            <element name="approximatePositionITRF">
-                <complexType>
-                    <!-- TODO Allow one or both, but not none of the allowed positioning points -->
-		            <sequence>
-		                <element name="cartesianPosition" type="geo:cartesianPosition" minOccurs="0"/>
-		                <element name="geodeticPosition" type="geo:geodeticPosition" minOccurs="0"/>
-		            </sequence>
-                </complexType>
-            </element>
-            
-            <element name="notes" type="string"/>
-        </sequence>
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element name="city" type="string"/>
+                    <element name="state" type="string"/>
+                    <element name="countryCodeISO" type="geo:countryCodeType" />
+                    <!-- TODO: use gco -->
+                    <element name="tectonicPlate" type="gml:CodeType"/>
+                    
+                    <element name="approximatePositionITRF">
+                        <complexType>
+                            <!-- TODO Allow one or both, but not none of the allowed positioning points -->
+                            <sequence>
+                                <element name="cartesianPosition" type="geo:cartesianPosition" minOccurs="0"/>
+                                <element name="geodeticPosition" type="geo:geodeticPosition" minOccurs="0"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                    
+                    <element name="notes" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
     </complexType>    
 </schema>


### PR DESCRIPTION
AbstractGMLType provides gml:id attribute to its subtypes. This id
attribute is part of target of xlink:href in SiteLocationPropertyType.